### PR TITLE
Home page 소개글, 최근 포스팅 레이아웃 적용

### DIFF
--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -22,4 +22,5 @@
 
 .main {
   width: 70%;
+  margin: 1rem;
 }

--- a/components/Home/Introduce/Introduce.module.css
+++ b/components/Home/Introduce/Introduce.module.css
@@ -1,0 +1,21 @@
+.my_introduce {
+  min-height: 30vh;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background-color: gray;
+  border-radius: 10px;
+}
+
+.title {
+  margin-top: 0;
+  color: #a9adc1;
+}
+
+.description {
+  font-weight: 400;
+  color: #a9adc1;
+}
+
+.recent_post {
+  height: 30px;
+}

--- a/components/Home/Introduce/index.tsx
+++ b/components/Home/Introduce/index.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from "next";
+
+import styles from "./Introduce.module.css";
+
+const Introduce: NextPage = () => {
+  return (
+    <div className={styles.my_introduce}>
+      <h2 className={styles.title}>Takhyun Kim</h2>
+      <h3 className={styles.description}>
+        Frontend Engieer
+        <br /> who likes to write documents and make plans.
+      </h3>
+    </div>
+  );
+};
+
+export default Introduce;

--- a/components/Home/RecentPosts/RecentPost.module.css
+++ b/components/Home/RecentPosts/RecentPost.module.css
@@ -1,0 +1,14 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.recent_posts_title {
+  margin-top: 0.7rem;
+  font-size: 2rem;
+}
+
+.recent_post_wrapper {
+  display: flex;
+}

--- a/components/Home/RecentPosts/RecentPost/RecentPost.module.css
+++ b/components/Home/RecentPosts/RecentPost/RecentPost.module.css
@@ -1,0 +1,20 @@
+.wrapper {
+  width: 100%;
+  margin-bottom: 2rem;
+}
+
+.recent_post_title {
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+}
+
+.recent_post_date {
+  margin-bottom: 0.5rem;
+  color: #a9adc1;
+  font-size: 0.8rem;
+}
+
+.recent_post_sub_title {
+  color: #a9adc1;
+  font-size: 1rem;
+}

--- a/components/Home/RecentPosts/RecentPost/index.tsx
+++ b/components/Home/RecentPosts/RecentPost/index.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from "next";
+
+import styles from "./RecentPost.module.css";
+
+const RecentPost: NextPage = () => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.recent_post_title}>title 을 적을 생각입니다.</div>
+      <div className={styles.recent_post_date}>2022년 08년 22일</div>
+      <div className={styles.recent_post_sub_title}>
+        sub title 을 적을 생각입니다.
+      </div>
+    </div>
+  );
+};
+
+export default RecentPost;

--- a/components/Home/RecentPosts/index.tsx
+++ b/components/Home/RecentPosts/index.tsx
@@ -1,0 +1,20 @@
+import type { NextPage } from "next";
+
+import RecentPost from "./RecentPost";
+
+import styles from "./RecentPost.module.css";
+
+const RecentPosts: NextPage = () => {
+  return (
+    <div className={styles.wrapper}>
+      <h2 className={styles.recent_posts_title}>최근 포스팅</h2>
+      <div>
+        <RecentPost />
+        <RecentPost />
+        <RecentPost />
+      </div>
+    </div>
+  );
+};
+
+export default RecentPosts;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,14 @@
 import type { NextPage } from "next";
 
 import Container from "../components/Container";
+import Introduce from "../components/Home/Introduce";
+import RecentPosts from "../components/Home/RecentPosts";
 
 const Home: NextPage = () => {
   return (
     <Container>
-      <span>HOME</span>
+      <Introduce />
+      <RecentPosts />
     </Container>
   );
 };


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 홈페이지에 소개글, 최근 포스팅에 대한 레이아웃을 적용

- 기타 참고 문서 : N/A

## 💻 Changes

RecentPost component 를 추가했습니다. 61b2761
최근 포스팅에 대한 정보를 간략하게 보여주는 용도의 component 입니다.

RecentPosts 즉, RecentPost 를 감싸는 형태의 component 를 추가했습니다. c66c70c

개인 소개글에 대한 component 를 추가했습니다. 0cac643
나중에 개인 사진을 포함한 component 로 만들 예정입니다.

## 🎥 ScreenShot or Video

<img width="800" alt="스크린샷 2022-08-11 오전 3 03 16" src="https://user-images.githubusercontent.com/64253365/183984530-0a807e4d-55d2-441f-b561-39b40fa7cbd9.png">
