### PR TITLE
Blog Title 추가 및 Header 레이아웃 변경

### DIFF
--- a/common/routes/index.tsx
+++ b/common/routes/index.tsx
@@ -1,8 +1,5 @@
 type NavLink = { title: string; link: string };
 
-const navLinks: NavLink[] = [
-  { title: "Home", link: "/" },
-  { title: "Blog", link: "/blog" },
-];
+const navLinks: NavLink[] = [{ title: "Blog", link: "/blog" }];
 
 export default navLinks;

--- a/components/BlogTitle/BlogTitle.module.css
+++ b/components/BlogTitle/BlogTitle.module.css
@@ -1,0 +1,4 @@
+.blog_title {
+  margin: 0;
+  letter-spacing: 0.1rem;
+}

--- a/components/BlogTitle/index.tsx
+++ b/components/BlogTitle/index.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from "next";
+import Link from "next/link";
+
+import styles from "./BlogTitle.module.css";
+
+const BlogTitle = () => {
+  return (
+    <h1 className={styles.blog_title}>
+      <Link href="/">Takhyun Blog</Link>
+    </h1>
+  );
+};
+
+export default BlogTitle;

--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -13,6 +13,10 @@
   margin: 2rem;
 }
 
+.nav_profile_wrapper {
+  display: flex;
+}
+
 .header_profile {
   width: 2.5rem;
   height: 2.5rem;

--- a/components/Container/index.tsx
+++ b/components/Container/index.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import Head from "next/head";
 
 import Nav from "../Nav";
+import BlogTitle from "../BlogTitle";
 
 import styles from "./Container.module.css";
 
@@ -16,8 +17,11 @@ const Container = (props: ContainerProps) => {
         <title>takhyun blog</title>
       </Head>
       <header className={styles.header}>
-        <Nav />
-        <div className={styles.header_profile} />
+        <BlogTitle />
+        <div className={styles.nav_profile_wrapper}>
+          <Nav />
+          <div className={styles.header_profile} />
+        </div>
       </header>
       <main className={styles.main}>{props.children}</main>
     </div>

--- a/components/Nav/Nav.module.css
+++ b/components/Nav/Nav.module.css
@@ -1,12 +1,13 @@
 .wrapper {
-  width: "100%";
-  flex: 1;
-  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 1.5rem;
 }
 
 .nav_text {
   margin-right: 1.5rem;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.6rem;
   font-size: 1.5rem;
   font-weight: 400;
   letter-spacing: 0.1rem;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Home navigation 를 삭제한 후 Blog Title 추가 및 Header 레이아웃을 변경했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

BlogTitle 컴포넌트를 추가했습니다. 기존 Home Hav 역할을 대체합니다. 1c24265

Home nav 삭제 및 기존 좌측에 존재하던 nav 레이아웃을 오른쪽 profile 옆으로 옮겼습니다.

## 🎥 ScreenShot or Video

<img width="700" alt="스크린샷 2022-08-13 오후 10 57 18" src="https://user-images.githubusercontent.com/64253365/184497435-6a87e3ec-4c1d-4321-bf67-f937f4a2650c.png">

