### PR TITLE
Main Footer 간격 조정 및 Footer layout 변경

### DIFF
--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -13,7 +13,7 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  padding-bottom: 2rem;
+  padding-bottom: 15rem;
 }
 
 .header {

--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -12,11 +12,16 @@
   color: #a9adc1;
 }
 
+.copyright_wrapper {
+  padding-right: 0.5rem;
+  border-right: 1px solid #a9adc1;
+}
+
 .github_wrapper {
   position: relative;
   width: 1rem;
   height: 1rem;
-  margin-right: 0.5rem;
+  margin-left: 0.5rem;
   border-radius: 50%;
   overflow: hidden;
 }

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -7,12 +7,14 @@ import styles from "./Footer.module.css";
 const Footer: NextPage = () => {
   return (
     <footer className={styles.footer_wrapper}>
+      <div className={styles.copyright_wrapper}>
+        Copyright © 2022 TakhyunKim{" "}
+      </div>
       <Link href="https://github.com/TakhyunKim">
         <a rel="noreferrer" target="_blank" className={styles.github_wrapper}>
           <Image src="/images/github.svg" alt="github icon" layout="fill" />
         </a>
       </Link>
-      <span>Copyright © 2022 TakhyunKim</span>
     </footer>
   );
 };


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Main Footer 간격이 좁아 컨텐츠 가독성에 문제가 있어, 간격을 조정했습니다.
            이와 더불어 copyright 바로 옆에 github 로고 한개만 존재하여 github 에 의해 만들어진 느낌을 준다는 피드백을 받아
            오른쪽으로 옮긴 후 구분선을 추가했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

main footer 간격을 늘렸습니다. b69692f

github icon 위치를 오른쪽으로 이동 후, 구분선을 위해 border right 를 적용했습니다. [bdbff2a](https://github.com/TakhyunKim/takhyun.dev/pull/31/commits/bdbff2a9ca817df5df5a8f278d5c0a39147606ea)

## 🎥 ScreenShot or Video

![footer 레이아웃 변경](https://user-images.githubusercontent.com/64253365/186080884-24d8286b-63cd-43d9-a108-ee7a878664ea.png)
![main footer 간격 개선](https://user-images.githubusercontent.com/64253365/186080951-22353e59-93c7-4885-a1f7-f314c1d7454b.png)

