### PR TITLE
모바일 썸네일 사이즈 변경

### DIFF
--- a/pages/styles/post.module.css
+++ b/pages/styles/post.module.css
@@ -87,3 +87,13 @@
   font-family: inherit;
   background: none;
 }
+
+@media (max-width: 768px) {
+  .thumbnail_wrapper {
+    position: relative;
+    width: 100%;
+    height: 15rem;
+    border-radius: 10px;
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 모바일에서 포스팅 썸네일 사이즈를 조정했습니다. (기존 비율이 좋지 않았음)

- 기타 참고 문서 : N/A

## 💻 Changes

thumbnail wrapper css 를 mobile size 에서 재선언했습니다. 
height 값을 기존 `35rem` 에서 `15rem` 으로 줄였습니다. 7368f65

## 🎥 ScreenShot or Video

### 변경 전 
<img width="232" alt="스크린샷 2022-09-11 오후 9 41 58" src="https://user-images.githubusercontent.com/64253365/189528111-535f5b41-088d-40ee-845f-ef353ff6f717.png">
### 변경 후
<img width="230" alt="스크린샷 2022-09-11 오후 9 42 09" src="https://user-images.githubusercontent.com/64253365/189528122-eac050e0-a733-4684-8bf2-7425c3074886.png">
