### PR TITLE
웹 접근성을 위한 Light mode text color 변경

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,7 @@
 :root {
   --bg-color: #ffffff;
   --text-color: #414141;
-  --description-text-color: #a9adc1;
+  --description-text-color: #585b63;
   --border-color: #a4a4a4;
   --box-shadow-color: #5c5f7014;
   --box-shadow-hovered-color: #5c5f701a;
@@ -28,6 +28,7 @@ body[data-theme="dark"] {
 body[data-theme="light"] {
   --bg-color: #ffffff;
   --text-color: #414141;
+  --description-text-color: #585b63;
   --border-color: #a4a4a4;
   --box-bg-hovered-color: #efeeee;
   --post-text-color: #343434;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Light mode 일 때 일부 text color 의 명암비가 좋지 않아 웹 접근성 개선을 위해 색상 변경을 했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

description text color 색을 변경했습니다. e9a11ae

## 🎥 ScreenShot or Video
변경 전
<img width="1182" alt="스크린샷 2022-09-13 오후 8 11 44" src="https://user-images.githubusercontent.com/64253365/189886763-2fd36f4f-bc0f-4e75-9f30-564c20df06dd.png">
변경 후
<img width="1136" alt="스크린샷 2022-09-13 오후 8 13 03" src="https://user-images.githubusercontent.com/64253365/189887022-5ca5da40-9ce9-4193-9667-8ae86411fd4d.png">
