### PR TITLE
목차 text color 및 border left 구분선 추가

### DIFF
--- a/components/Posts/TableOfContents/TableOfContents.module.css
+++ b/components/Posts/TableOfContents/TableOfContents.module.css
@@ -5,6 +5,7 @@
   right: 1%;
   transform: translateY(-50%);
   font-size: 0.8rem;
+  color: var(--post-text-color);
   border-left: 2px solid var(--border-color);
 }
 
@@ -14,6 +15,10 @@
 
 .table_of_content {
   padding-bottom: 0.35rem;
+}
+
+.table_of_content:hover {
+  color: var(--text-color);
 }
 
 @media (max-width: 768px) {

--- a/components/Posts/TableOfContents/TableOfContents.module.css
+++ b/components/Posts/TableOfContents/TableOfContents.module.css
@@ -5,6 +5,7 @@
   right: 1%;
   transform: translateY(-50%);
   font-size: 0.8rem;
+  border-left: 2px solid var(--border-color);
 }
 
 .table_of_contents_wrapper ul {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 목차와 본문과의 구분선 추가 및 텍스트 색상을 변경했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

border left style 을 적용하여 본문과의 구분선을 추가했습니다. ccb030b

default text color 지정 및 hover 되었을 때 text color style 도 추가했습니다. 3e3cdf4

## 🎥 ScreenShot or Video

<img width="309" alt="스크린샷 2022-09-27 오전 1 29 44" src="https://user-images.githubusercontent.com/64253365/192331344-28f8214c-8d37-4a37-bf8e-a4ba6fd63163.png">

