### PR TITLE
최신 포스팅 리스트에 projects 포스팅 포함 기능 구현

### DIFF
--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -77,6 +77,44 @@ export const getSortedPostsData = ({ postType }: PostType) => {
   });
 };
 
+export const getPostingData = ({ postType }: PostType) => {
+  const postingDirectory = path.join(process.cwd(), postType);
+  const postingFileNames = fs.readdirSync(postingDirectory);
+
+  const allPostsData = postingFileNames.map((fileName) => {
+    const id = fileName.replace(/\.md$/, "");
+
+    const fullPath = path.join(postingDirectory, fileName);
+    const fileContents = fs.readFileSync(fullPath, "utf8");
+
+    const matterResult = matter(fileContents);
+    const tagList = matterResult.data?.tag.split(",");
+
+    return {
+      id,
+      tagList,
+      ...matterResult.data,
+    } as PostData;
+  });
+
+  return allPostsData;
+};
+
+export const getSortedPostsAndProjectsData = () => {
+  const allPostsData = getPostingData({ postType: "posts" });
+  const allProjectsData = getPostingData({ postType: "projects" });
+
+  const allPostsAndProjectsData = [...allPostsData, ...allProjectsData];
+
+  return allPostsAndProjectsData.sort((a, b) => {
+    if (a.date < b.date) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
+};
+
 export const getAllPostIds = ({ postType }: PostType) => {
   const postsDirectory = path.join(process.cwd(), postType);
   const fileNames = fs.readdirSync(postsDirectory);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage, GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
 
-import { getSortedPostsData } from "../lib/posts";
+import { getSortedPostsAndProjectsData } from "../lib/posts";
 import type { PostData } from "../lib/posts";
 
 import Container from "../components/Container";
@@ -40,7 +40,7 @@ const Home: NextPage<HomeProps> = ({ recentPosts }) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const recentPosts = getSortedPostsData({ postType: "posts" }).slice(0, 3);
+  const recentPosts = getSortedPostsAndProjectsData().slice(0, 3);
 
   return {
     props: {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 최신 포스팅 리스트에 projects 포스팅 포함 기능 구현하는 목적입니다.

- 기타 참고 문서 : N/A

## 💻 Changes

`getPostingData` util function 을 추가해서 로직을 분리 후,
projects, posts 디렉토리에 대한 data 를 취합한 list 를 return 하는 방향으로 변경했습니다. 

index 에서는 이제 projects 도 최신 포스팅 리스트에 포함하여 표기합니다.

## 🎥 ScreenShot or Video

<img width="1098" alt="스크린샷 2022-11-06 오전 2 11 06" src="https://user-images.githubusercontent.com/64253365/200132583-5659bbd6-bd44-40f2-b983-b14fd15a6774.png">

