### PR TITLE
NotFound 페이지 추가

### DIFF
--- a/components/NotFound/NotFoundHeader/NotFoundHeader.module.css
+++ b/components/NotFound/NotFoundHeader/NotFoundHeader.module.css
@@ -1,0 +1,23 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.not_found_header {
+  margin: 0.5rem 0;
+  color: var(--description-text-color);
+}
+
+.not_found_status_code {
+  color: var(--description-text-color);
+  margin: 0;
+  font-size: 5rem;
+}
+
+.not_found_sub_comment {
+  margin: 0.5rem 0;
+  font-size: 2rem;
+  font-weight: bold;
+  line-height: 3rem;
+}

--- a/components/NotFound/NotFoundHeader/NotFoundHeader.module.css
+++ b/components/NotFound/NotFoundHeader/NotFoundHeader.module.css
@@ -21,3 +21,8 @@
   font-weight: bold;
   line-height: 3rem;
 }
+
+.not_found_comment {
+  font-weight: 300;
+  line-height: 2rem;
+}

--- a/components/NotFound/NotFoundHeader/index.tsx
+++ b/components/NotFound/NotFoundHeader/index.tsx
@@ -12,6 +12,14 @@ const NotFoundHeader: NextPage = () => {
         <br /> nothing,
         <br /> something.
       </p>
+      <p className={styles.not_found_comment}>
+        찾으시려는 페이지는 존재하지 않습니다.
+        <br />
+        다른 글을 보실려면 상단 posts, projects 메뉴를 누르시거나.
+        <br />
+        아래에 최신글을 읽어보시길 바랍니다 :D
+        <br />
+      </p>
     </div>
   );
 };

--- a/components/NotFound/NotFoundHeader/index.tsx
+++ b/components/NotFound/NotFoundHeader/index.tsx
@@ -1,0 +1,19 @@
+import type { NextPage } from "next";
+
+import styles from "./NotFoundHeader.module.css";
+
+const NotFoundHeader: NextPage = () => {
+  return (
+    <div className={styles.wrapper}>
+      <p className={styles.not_found_header}>PAGE NOT FOUND</p>
+      <h2 className={styles.not_found_status_code}>404</h2>
+      <p className={styles.not_found_sub_comment}>
+        Out of
+        <br /> nothing,
+        <br /> something.
+      </p>
+    </div>
+  );
+};
+
+export default NotFoundHeader;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,49 @@
-const NotFound = () => {
-  return <q>404</q>;
+import type { NextPage, GetStaticProps } from "next";
+import { NextSeo } from "next-seo";
+import Image from "next/image";
+
+import { getSortedPostsAndProjectsData } from "../lib/posts";
+import type { PostData } from "../lib/posts";
+
+import NotFoundHeader from "../components/NotFound/NotFoundHeader";
+import RecentPosts from "../components/Home/RecentPosts";
+
+import styles from "./styles/notFound.module.css";
+
+interface NotFoundProps {
+  recentPosts: PostData[];
+}
+
+const NotFound: NextPage<NotFoundProps> = ({ recentPosts }) => {
+  return (
+    <>
+      <NextSeo
+        title="Takhyun Kim & Frontend Engineer"
+        description="프론트엔드 개발자 김탁현의 기술 블로그"
+      />
+      <div className={styles.header_wrapper}>
+        <div className={styles.intro_profile}>
+          <Image
+            src="/images/intro-profile.jpg"
+            layout="fill"
+            alt="intro profile"
+          />
+        </div>
+        <NotFoundHeader />
+      </div>
+      <RecentPosts postList={recentPosts} />
+    </>
+  );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const recentPosts = getSortedPostsAndProjectsData().slice(0, 3);
+
+  return {
+    props: {
+      recentPosts,
+    },
+  };
 };
 
 export default NotFound;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,5 @@
+const NotFound = () => {
+  return <q>404</q>;
+};
+
+export default NotFound;

--- a/pages/styles/notFound.module.css
+++ b/pages/styles/notFound.module.css
@@ -1,0 +1,16 @@
+.header_wrapper {
+  display: flex;
+
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.intro_profile {
+  position: relative;
+  width: 20rem;
+  height: 20rem;
+  margin-right: 10rem;
+  border-radius: 50%;
+  box-shadow: 2px 2px 6px #3e3e3f;
+  overflow: hidden;
+}


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 기존 next js 404 페이지에서 커스텀된 404 페이지를 추가했습니다.

- 기타 참고 문서 : https://nextjs.org/docs/advanced-features/custom-error-page

## 💻 Changes

custom 404 page 추가 d6766dd

404 페이지에 대한 코멘트를 작성한 NotFoundHeader component 를 추가했습니다. 700f7c6

Intro profile, NotFoundHeader 및 최신 포스팅을 404 페이지에 추가했습니다.  329ce88 

## 🎥 ScreenShot or Video

<img width="1160" alt="스크린샷 2022-11-19 오후 12 40 33" src="https://user-images.githubusercontent.com/64253365/202832642-fe97c53f-b9c9-4cac-8bd7-08dd3036156f.png">

