### PR TITLE
Footer Copyright 현재 Year 적용

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -8,7 +8,7 @@ const Footer: NextPage = () => {
   return (
     <footer className={styles.footer_wrapper}>
       <div className={styles.copyright_wrapper}>
-        Copyright © 2022 TakhyunKim{" "}
+        Copyright © {new Date().getFullYear()} TakhyunKim{" "}
       </div>
       <Link href="https://github.com/TakhyunKim">
         <a rel="noreferrer" target="_blank" className={styles.github_wrapper}>


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : footer 에 표기된 년도를 항상 현재 년도로 유지할 수 있도록 개선했습니다.

- 기타 참고 문서 : N/A

## 💻 Changes

date 를 이용하여 현재 년도를 표기할 수 있도록 수정했습니다. 4131781

## 🎥 ScreenShot or Video
<img width="464" alt="스크린샷 2023-02-27 오전 12 03 41" src="https://user-images.githubusercontent.com/64253365/221418713-87a64169-feb1-45b9-b30f-61b211902c17.png">


