### PR TITLE
IOS / Safari Lookbehind 패턴 미지원 대응

### DIFF
--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -42,9 +42,16 @@ const components = {
     const substrings = props.alt.split("{");
     const alt = substrings[0].trim();
     const imgInfo = substrings[1];
-    const imgWidth = imgInfo.match(/(?<=w:\s?)\d+/g);
-    const imgHeight = imgInfo.match(/(?<=h:\s?)\d+/g);
-    const parentImgWidth = imgInfo.match(/(?<=parentW:\s?)\d+/g);
+
+    const imgWidth = imgInfo
+      .match(/w:\s\d+/g)
+      ?.map((match) => match.replace("w: ", ""));
+    const imgHeight = imgInfo
+      .match(/h:\s\d+/g)
+      ?.map((match) => match.replace("h: ", ""));
+    const parentImgWidth = imgInfo
+      .match(/parentW:\s\d+/g)
+      ?.map((match) => match.replace("parentW: ", ""));
 
     const width = imgWidth ? imgWidth[0] : 600;
     const height = imgHeight ? imgHeight[0] : 300;


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Reg Lookbehind 패턴을 사용한 부분이 IOS / Safari 환경을 지원하지 않아 발생하는 에러 대응

- 기타 참고 문서 : 
   [ios chrome 환경에서 Lookbehind 문법 적용 안되는 내용 정리 블로그](https://kunkunwoo.tistory.com/213)
   [safari invalid regular expression stackoverflow](https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group)
   [caniuse lookbehind](https://caniuse.com/js-regexp-lookbehind)

## 💻 Changes

lookbehind reg pattern 을 대체하여 미지원 되는 브라우저를 커버합니다. 7a51791

## 🎥 ScreenShot or Video

N/A
