### PR TITLE
브라우저 max-width 가 1200px 일 때에 대한 css 적용

### DIFF
--- a/components/PostList/PostList.module.css
+++ b/components/PostList/PostList.module.css
@@ -10,6 +10,15 @@
   column-gap: 1rem;
 }
 
+@media (max-width: 1200px) {
+  .post_list_wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    row-gap: 2rem;
+    column-gap: 1rem;
+  }
+}
+
 /** 모바일 css */
 @media (max-width: 768px) {
   .post_list_wrapper {


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 브라우저 max-width 가 1200px 일 때 포스팅 리스트 레이아웃이 깨지지 않도록 기존 3칸에서
            2칸으로 줄이는 스타일 적용

- 기타 참고 문서 : N/A

## 💻 Changes

PostList Component 에 max-width 1200px 에 대한 스타일 적용 5819db5

## 🎥 ScreenShot or Video

<img width="725" alt="스크린샷 2023-06-06 오전 12 05 52" src="https://github.com/TakhyunKim/takhyun.dev/assets/64253365/64b281f1-e825-470a-ab5f-e6478dbcf56a">

